### PR TITLE
Make compatible with HACS

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,7 @@
+{
+  "name": "shairport-sync media_player",
+  "render_readme": true,
+  "content_in_root": true,
+  "iot_class": ["Local Push"],
+  "domains": ["media_player"]
+}


### PR DESCRIPTION
Hello -

Thank you for writing this! I noticed that I couldn't install the repo in HACS, and this config file was all that was missing. With it, any user can add this repo as a "custom repository" in their own HACS setup, and then install it via the UI (no need to shell into the homeassistant instance and download it manually, etc). I've confirmed this works on the `master` branch of my fork.