### PR TITLE
Update manifest.json

### DIFF
--- a/shairport_sync/manifest.json
+++ b/shairport_sync/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "shairport_sync",
   "name": "Shairport Sync Media Player",
+  "version": "1.0.0",
   "documentation": "https://github.com/parautenbach/hass-shairport-sync/",
   "requirements": [],
   "dependencies": [


### PR DESCRIPTION
Thank you for the excellent integration!

This fixes a warning within HA:

`No 'version' key in the manifest file for custom integration 'shairport_sync'. As of Home Assistant 2021.6, this integration will no longer be loaded. Please report this to the maintainer of 'shairport_sync'`