### PR TITLE
Add support for active_end message

### DIFF
--- a/custom_components/shairport_sync/const.py
+++ b/custom_components/shairport_sync/const.py
@@ -5,6 +5,7 @@ DOMAIN = "shairport_sync"
 
 # OFF_STATES = [STATE_IDLE, STATE_OFF, STATE_UNAVAILABLE]
 
+
 class Command(StrEnum):
     """Remote commands for Shairport Sync."""
 
@@ -16,6 +17,7 @@ class Command(StrEnum):
     VOLUME_DOWN = "volumedown"
     VOLUME_UP = "volumeup"
 
+
 class TopLevelTopic(StrEnum):
     """Top level topics for Shairport Sync."""
 
@@ -26,8 +28,6 @@ class TopLevelTopic(StrEnum):
     PLAY_FLUSH = "play_flush"
     PLAY_START = "play_start"
     PLAY_RESUME = "play_resume"
+    ACTIVE_END = "active_end"
     REMOTE = "remote"
     TITLE = "title"
-
-
-

--- a/custom_components/shairport_sync/media_player.py
+++ b/custom_components/shairport_sync/media_player.py
@@ -140,26 +140,14 @@ class ShairportSyncMediaPlayer(MediaPlayerEntity):
             _LOGGER.debug("Active ended")
             self._set_state(MediaPlayerState.IDLE)
 
-        @callback
-        def artist_updated(message) -> None:
-            """Handle the artist updated MQTT message."""
-            self._artist = message.payload
-            _LOGGER.debug("New artist: %s", self._artist)
-            self.async_write_ha_state()
+        def set_metadata(attr):
+            """Construct a callback that sets the desired metadata attribute."""
+            @callback
+            def F(msg) -> None:
+                setattr(self, f"_{attr}", msg.payload)
+                _LOGGER.debug(f"New {attr}: {msg.payload}")
 
-        @callback
-        def album_updated(message) -> None:
-            """Handle the album updated MQTT message."""
-            self._album = message.payload
-            _LOGGER.debug("New album: %s", self._album)
-            self.async_write_ha_state()
-
-        @callback
-        def title_updated(message) -> None:
-            """Handle the title updated MQTT message."""
-            self._title = message.payload
-            _LOGGER.debug("New title: %s", self._title)
-            self.async_write_ha_state()
+            return F
 
         @callback
         def artwork_updated(message) -> None:
@@ -179,9 +167,9 @@ class ShairportSyncMediaPlayer(MediaPlayerEntity):
             TopLevelTopic.PLAY_END: (play_ended, "utf-8"),
             TopLevelTopic.PLAY_FLUSH: (play_ended, "utf-8"),
             TopLevelTopic.ACTIVE_END: (active_ended, "utf-8"),
-            TopLevelTopic.ARTIST: (artist_updated, "utf-8"),
-            TopLevelTopic.ALBUM: (album_updated, "utf-8"),
-            TopLevelTopic.TITLE: (title_updated, "utf-8"),
+            TopLevelTopic.ARTIST: (set_metadata("artist"), "utf-8"),
+            TopLevelTopic.ALBUM: (set_metadata("album"), "utf-8"),
+            TopLevelTopic.TITLE: (set_metadata("title"), "utf-8"),
             TopLevelTopic.COVER: (artwork_updated, None),
         }
 

--- a/custom_components/shairport_sync/media_player.py
+++ b/custom_components/shairport_sync/media_player.py
@@ -122,6 +122,13 @@ class ShairportSyncMediaPlayer(MediaPlayerEntity):
             self.async_write_ha_state()
 
         @callback
+        def active_ended(_) -> None:
+            """Handle the active ended MQTT message."""
+            _LOGGER.debug("Active ended")
+            self._player_state = MediaPlayerState.IDLE
+            self.async_write_ha_state()
+
+        @callback
         def artist_updated(message) -> None:
             """Handle the artist updated MQTT message."""
             self._artist = message.payload
@@ -159,6 +166,7 @@ class ShairportSyncMediaPlayer(MediaPlayerEntity):
             TopLevelTopic.PLAY_RESUME: (play_started, "utf-8"),
             TopLevelTopic.PLAY_END: (play_ended, "utf-8"),
             TopLevelTopic.PLAY_FLUSH: (play_ended, "utf-8"),
+            TopLevelTopic.ACTIVE_END: (active_ended, "utf-8"),
             TopLevelTopic.ARTIST: (artist_updated, "utf-8"),
             TopLevelTopic.ALBUM: (album_updated, "utf-8"),
             TopLevelTopic.TITLE: (title_updated, "utf-8"),


### PR DESCRIPTION
Subscribe to the active_end message and set the player state to idle.

Also:
- Clear the metadata on Idle state to remove stale data from the media card.
- Construct metadata callbacks from a single point
